### PR TITLE
Upgraded to bevy 0.14.0; All tests and examples passing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   CARGO_TERM_COLOR: always
@@ -8,23 +8,29 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: [stable]
+        toolchain: [stable, nightly]
+        op: [build, test, clippy]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
         with:
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
           components: rustfmt, clippy
+          override: true
 
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
         if: runner.os == 'linux'
 
       - name: Setup cache
-        uses: actions/cache@v4
+        uses: actions/cache@v2
         with:
           path: |
             ~/.cargo/registry
@@ -32,10 +38,15 @@ jobs:
             target
           key: ${{ runner.os }}-test-rustc-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - run: cargo fmt --all -- --check
+      - uses: actions-rs/cargo@v1
         if: runner.os == 'linux'
+        with:
+          command: fmt
+          args: --all -- --check
 
-      - run: cargo clippy --all-features
-        if: runner.os == 'linux'
-
-      - run: cargo test  --workspace
+      - uses: actions-rs/cargo@v1
+        with:
+          command: ${{ matrix.op }}
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ default = []
 serde = ["steamworks/serde"]
 
 [dependencies]
-bevy_log = "0.13"
-bevy_app = "0.13"
-bevy_ecs = "0.13"
-bevy_utils = "0.13"
+bevy_log = "0.14"
+bevy_app = "0.14"
+bevy_ecs = "0.14"
+bevy_utils = "0.14"
 steamworks = "0.11"
 
 [dev-dependencies]
-bevy = "0.13"
+bevy = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bevy_log = "0.14"
 bevy_app = "0.14"
 bevy_ecs = "0.14"
 bevy_utils = "0.14"
-steamworks = "0.11"
+steamworks = { git = "https://github.com/Noxime/steamworks-rs.git", tag="v0.11.0"}
 
 [dev-dependencies]
 bevy = "0.14"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -19,5 +19,5 @@ fn main() {
         .add_plugins(SteamworksPlugin::init_app(480).unwrap())
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, steam_system)
-        .run()
+        .run();
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -16,7 +16,7 @@ fn main() {
     // Use the demo Steam AppId for SpaceWar
     App::new()
         // it is important to add the plugin before `RenderPlugin` that comes with `DefaultPlugins`
-        .add_plugins(SteamworksPlugin::init_app(480).unwrap())
+        .add_plugins(SteamworksPlugin::init_app(480).expect("Steam is not currently running. Make sure to handle this possibility if you want to allow running without Steam!"))
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, steam_system)
         .run();

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -16,7 +16,7 @@ fn main() {
     // Use the demo Steam AppId for SpaceWar
     App::new()
         // it is important to add the plugin before `RenderPlugin` that comes with `DefaultPlugins`
-        .add_plugins(SteamworksPlugin::init_app(480).expect("Steam is not currently running. Make sure to handle this possibility if you want to allow running without Steam!"))
+        .add_plugins(SteamworksPlugin::init_app(480).unwrap())
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, steam_system)
         .run();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!       // it is important to add the plugin before `RenderPlugin` that comes with `DefaultPlugins`
 //!       .add_plugins(SteamworksPlugin::init_app(480).unwrap())
 //!       .add_plugins(DefaultPlugins)
-//!       .run()
+//!       .run();
 //! }
 //! ```
 //!
@@ -52,7 +52,7 @@
 //!       .add_plugins(SteamworksPlugin::init_app(480).unwrap())
 //!       .add_plugins(DefaultPlugins)
 //!       .add_systems(Startup, steam_system)
-//!       .run()
+//!       .run();
 //! }
 //! ```
 


### PR DESCRIPTION
I imagine at first look this is a duplicate of #37 but with this PR I made sure tests were passing (Including doc tests) and the example (which acts as a decent integration test).

I was also tempted to add an `expect` call in the example to make panics more easily understood. Since the only reason the example *would* panic is if a steam client is not currently running as well. While it may be fairly obvious I think it could help to signal to newer users that what's being done isn't handling the potential for a panic.

For example in my use case I wish to distrubute across Steam and Itch IO. An Itch user shouldn't be expected to have a steam client running so I'd rather just handle it with some control statements.

Otherwise thanks a ton for making this crate! I'm really excited to integrate steamworks and this crate makes it super easy!