### PR TITLE
Update to Bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ default = []
 serde = ["steamworks/serde"]
 
 [dependencies]
-bevy_log = "0.14"
-bevy_app = "0.14"
-bevy_ecs = "0.14"
-bevy_utils = "0.14"
+bevy_log = "0.15"
+bevy_app = "0.15"
+bevy_ecs = "0.15"
+bevy_utils = "0.15"
 steamworks = "0.11"
 
 [dev-dependencies]
-bevy = "0.14"
+bevy = "0.15"


### PR DESCRIPTION
The example works and tests pass. It seems there is no need to make any changes other than bumping the versions.