### PR TITLE
Update to bevy version 0.15 + rename resource: Client to SteamworksClient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-steamworks"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["james7132 <contact@jamessliu.com>"]
 edition = "2021"
 description = "A Bevy plugin for integrating with the Steamworks SDK."
@@ -13,11 +13,11 @@ default = []
 serde = ["steamworks/serde"]
 
 [dependencies]
-bevy_log = "0.14"
-bevy_app = "0.14"
-bevy_ecs = "0.14"
-bevy_utils = "0.14"
+bevy_log = "0.15"
+bevy_app = "0.15"
+bevy_ecs = "0.15"
+bevy_utils = "0.15"
 steamworks = "0.11"
 
 [dev-dependencies]
-bevy = "0.14"
+bevy = "0.15"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy_steamworks::*;
 
-fn steam_system(steam_client: Res<Client>) {
+fn steam_system(steam_client: Res<SteamworksClient>) {
     for friend in steam_client.friends().get_friends(FriendFlags::IMMEDIATE) {
         println!(
             "Friend: {:?} - {}({:?})",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,9 +152,9 @@ macro_rules! register_event_callbacks {
 ///
 /// For more information on how to use it, see [`steamworks::Client`].
 #[derive(Resource, Clone)]
-pub struct Client(steamworks::Client);
+pub struct SteamworksClient(steamworks::Client);
 
-impl Deref for Client {
+impl Deref for SteamworksClient {
     type Target = steamworks::Client;
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -162,7 +162,7 @@ impl Deref for Client {
 }
 
 #[derive(Resource)]
-struct SingleClient(SyncCell<steamworks::SingleClient>);
+struct SteamworksSingleClient(SyncCell<steamworks::SingleClient>);
 
 /// A Bevy [`Plugin`] for adding support for the Steam SDK.
 pub struct SteamworksPlugin {
@@ -198,8 +198,8 @@ impl Plugin for SteamworksPlugin {
             .take()
             .expect("The SteamworksPlugin was initialized more than once");
 
-        app.insert_resource(Client(client.clone()))
-            .insert_resource(SingleClient(SyncCell::new(single)))
+        app.insert_resource(SteamworksClient(client.clone()))
+            .insert_resource(SteamworksSingleClient(SyncCell::new(single)))
             .insert_resource(register_event_callbacks!(
                 client,
                 AuthSessionTicketResponse,
@@ -241,7 +241,7 @@ pub enum SteamworksSystem {
 }
 
 fn run_steam_callbacks(
-    mut client: ResMut<SingleClient>,
+    mut client: ResMut<SteamworksSingleClient>,
     events: Res<SteamEvents>,
     mut output: EventWriter<SteamworksEvent>,
 ) {


### PR DESCRIPTION
`Client` is too generic when working with multiple crates which include "clients."

Bevy is updated to 0.15 with no changes needed to the codebase.

Bumped package version to 0.13