### PR TITLE
Update crate to v0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-steamworks"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["james7132 <contact@jamessliu.com>"]
 edition = "2021"
 description = "A Bevy plugin for integrating with the Steamworks SDK."

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bevy-steamworks = "0.12"
+bevy-steamworks = "0.13"
 ```
 
 The steamworks crate comes bundled with the redistributable dynamic libraries
@@ -22,7 +22,7 @@ If you wish to enable serde support add the following:
 
 ```toml
 [dependencies]
-bevy-steamworks = { version = "0.12", features = ["serde"] }
+bevy-steamworks = { version = "0.13", features = ["serde"] }
 ```
 
 ## Usage
@@ -79,6 +79,7 @@ fn main() {
  
 |Bevy Version |bevy\_steamworks|
 |:------------|:---------------|
+|0.15         |0.13            |
 |0.14         |0.12            |
 |0.13         |0.10, 0.11      |
 |0.12         |0.9             |


### PR DESCRIPTION
This release is only to match a version bump to `bevy` v0.15.