### PR TITLE
Add option to create plugin with given client

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,15 @@ impl SteamworksPlugin {
             steam: Mutex::new(Some(steamworks::Client::init()?)),
         })
     }
+
+    /// Creates a new `SteamworksPlugin` with an existing `steamworks::Client`.
+    /// This is useful when you want to initialize the client separately
+    /// from the plugin.
+    pub fn with(client: steamworks::Client) -> Result<Self, SteamAPIInitError> {
+        Ok(Self {
+            steam: Mutex::new(Some(client)),
+        })
+    }
 }
 
 impl Plugin for SteamworksPlugin {


### PR DESCRIPTION
Not sure if this makes sense to merge, but I needed this for [aeronet_steam](https://github.com/aecsocket/aeronet/tree/main/crates/aeronet_steam).

### Change
This adds the option to create `SteamworksPlugin` using a new function `with` instead of having to `init` the steam `Client` from within the Plugin.

### Problem
Third-party crate needs access to `Client<ClientManager>`.

### Solution
This adds easy option to `init` the `Client` from outside the plugin and pass in the client.