### PR TITLE
Update README.md to reflect new minimum SDK version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ bevy-steamworks = "0.16"
 ```
 
 The steamworks crate comes bundled with the redistributable dynamic libraries
-of a compatible version of the SDK. Currently it's v158a.
+of a compatible version of the SDK. Currently it's v1.62.
 
 If you wish to enable serde support add the following:
 


### PR DESCRIPTION
Since this crate uses `steamworks-rs` at version `0.12.0` or above and `steamworks-rs` requires SDK 1.62, this crate transitively requires 1.62 as well. Confirmed 1.58a doesn't work with an updated version of my own game. See https://github.com/Noxime/steamworks-rs

<img width="240" height="248" alt="image" src="https://github.com/user-attachments/assets/9b2fdf47-26a1-45ba-820b-d088ab66bec2" />
