### PR TITLE
Add a Nix flake for Bevy development

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,69 @@
+{
+  "nodes": {
+    "bevy-flake": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782551976,
+        "narHash": "sha256-PyoqkFdStbN40C0/kY9Dbygl13LULhmVmEkzHnSlAnU=",
+        "owner": "swagtop",
+        "repo": "bevy-flake",
+        "rev": "d45229a7b3c76c38aeeed77f84a6d6178c4c76dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "swagtop",
+        "repo": "bevy-flake",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782959384,
+        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "bevy-flake": "bevy-flake",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783058364,
+        "narHash": "sha256-felUcVUtcdI15evRNkVfLq3opwceShhbrJt6hDlZvrk=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e7a078c7feb51f37955a832b22a96de5fccb1f7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,88 @@
+{
+  description = "A flake using Oxalica's rust-overlay wrapped with bevy-flake.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    bevy-flake = {
+      url = "github:swagtop/bevy-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      bevy-flake,
+      rust-overlay,
+      ...
+    }:
+    bevy-flake.lib.mkFlake {
+      perSystem =
+        {
+          pkgs,
+          system,
+          packages,
+          formatter,
+          ...
+        }:
+        {
+          inherit packages formatter;
+
+          devShells.default = pkgs.mkShell {
+            name = "bevy-flake-rust-overlay";
+            packages = [
+              packages.rust-toolchain.develop
+              packages.dioxus-cli.develop
+              # packages.bevy-cli.develop
+            ];
+          };
+        };
+
+      config =
+        {
+          pkgs,
+          system,
+          ...
+        }:
+        {
+          src = builtins.path {
+            name = "src";
+            path = ./.;
+
+            # Ignore files that aren't needed in compilation of Bevy project.
+            filter =
+              path: type:
+              !(builtins.elem (baseNameOf path) [
+                "flake.lock"
+                "flake.nix"
+              ]);
+          };
+
+          rustToolchain =
+            targets:
+            let
+              channel = "stable"; # For nightly, use "nightly".
+            in
+            pkgs.rust-bin.${channel}.latest.default.override {
+              inherit targets;
+              extensions = [
+                "rust-src"
+                "rust-analyzer"
+              ];
+            };
+
+          withPkgs = import nixpkgs {
+            inherit system;
+            overlays = [ (import rust-overlay) ];
+            config = {
+              allowUnfree = true;
+              microsoftVisualStudioLicenseAccepted = true;
+            };
+          };
+        };
+    };
+}


### PR DESCRIPTION
Using bevy-flake to bootstrap a nix devshell for bevy_steamworks.